### PR TITLE
patch libtess2 to make it match Spline's

### DIFF
--- a/Include/tesselator.h
+++ b/Include/tesselator.h
@@ -122,11 +122,17 @@ enum TessElementType
 // TESS_REVERSE_CONTOURS
 //   If enabled, tessAddContour() will treat CW contours as CCW and vice versa
 //   Disabled by default.
+//
+// TESS_USE_INDEX_RANGE
+//   If enabled, tess will compute additional index information for boundary contours
+//	 Based of Spline's VectorExtrusionGeometry.ts
+//   Disabled by default.
 
 enum TessOption
 {
 	TESS_CONSTRAINED_DELAUNAY_TRIANGULATION,
-	TESS_REVERSE_CONTOURS
+	TESS_REVERSE_CONTOURS,
+	TESS_USE_INDEX_RANGE
 };
 
 typedef float TESSreal;

--- a/Source/mesh.c
+++ b/Source/mesh.c
@@ -81,6 +81,8 @@ static TESShalfEdge *MakeEdge( TESSmesh* mesh, TESShalfEdge *eNext )
 	e->winding = 0;
 	e->activeRegion = NULL;
 	e->mark = 0;
+    e->idx0 = 0;
+    e->idx1 = 0;
 
 	eSym->Sym = e;
 	eSym->Onext = eSym;
@@ -90,6 +92,8 @@ static TESShalfEdge *MakeEdge( TESSmesh* mesh, TESShalfEdge *eNext )
 	eSym->winding = 0;
 	eSym->activeRegion = NULL;
 	eSym->mark = 0;
+    eSym->idx0 = 0;
+    eSym->idx1 = 0;
 
 	return e;
 }
@@ -470,6 +474,12 @@ TESShalfEdge *tessMeshSplitEdge( TESSmesh *mesh, TESShalfEdge *eOrg )
 	eNew->winding = eOrg->winding;	/* copy old winding information */
 	eNew->Sym->winding = eOrg->Sym->winding;
 
+    /* copy edge labels */
+    eNew->idx0 = eOrg->idx0;
+    eNew->idx1 = eOrg->idx1;
+    eNew->Sym->idx0 = eOrg->Sym->idx0;
+    eNew->Sym->idx1 = eOrg->Sym->idx1;
+
 	return eNew;
 }
 
@@ -631,6 +641,8 @@ TESSmesh *tessMeshNewMesh( TESSalloc* alloc )
 	e->Lface = NULL;
 	e->winding = 0;
 	e->activeRegion = NULL;
+    e->idx0 = 0;
+    e->idx1 = 0;
 
 	eSym->next = eSym;
 	eSym->Sym = e;
@@ -640,6 +652,8 @@ TESSmesh *tessMeshNewMesh( TESSalloc* alloc )
 	eSym->Lface = NULL;
 	eSym->winding = 0;
 	eSym->activeRegion = NULL;
+    eSym->idx0 = 0;
+    eSym->idx1 = 0;
 
 	return mesh;
 }

--- a/Source/mesh.h
+++ b/Source/mesh.h
@@ -139,6 +139,10 @@ struct TESShalfEdge {
 	TESSvertex *Org;       /* origin vertex (Overtex too long) */
 	TESSface *Lface;     /* left face */
 
+    /* Spline patch: edges are labelled with idx [i, i+1] (from, to) */
+    TESSindex idx0;
+    TESSindex idx1;
+
 	/* Internal data (keep hidden) */
 	ActiveRegion *activeRegion;  /* a region with this upper edge (sweep.c) */
 	int winding;    /* change in winding number when crossing

--- a/Source/tess.h
+++ b/Source/tess.h
@@ -63,6 +63,7 @@ struct TESStesselator {
 
 	int processCDT;	/* option to run Constrained Delayney pass. */
 	int reverseContours; /* tessAddContour() will treat CCW contours as CW and vice versa */
+    int useIndexRange; /* tess will compute additional index information for boundary contours */
     
 	/*** state needed for the line sweep ***/
 	int	windingRule;	/* rule for determining polygon interior */


### PR DESCRIPTION
This change replicates the changes made by [this patch](https://github.com/alelepd/spline/blob/dev/packages/spe/patches/tess2.patch).

Biggest difference is that the original patch adds a more general way to extend tess2 with custom callbacks and a generic type for vertexIndices. That being said, this feature is only used in a [single place](https://github.com/alelepd/spline/blob/0270e7af4cdacd554932213146897834eba23b7f/packages/spe/src/geometries/vectors/ExtrusionGeometry.ts#L635) in Spline.
I made the change such that the original callback's logic is now part of libtess2 and added a new option to enable this new logic when needed (disabled by default).